### PR TITLE
Fix kubeadm hostname "node" could not be reached

### DIFF
--- a/e2e-packet/cloud-config.yaml.tftpl
+++ b/e2e-packet/cloud-config.yaml.tftpl
@@ -55,7 +55,7 @@ write_files:
       ---
       apiVersion: kubeadm.k8s.io/v1beta3
       kind: ClusterConfiguration
-      kubernetesVersion: 1.27.0
+      kubernetesVersion: 1.27.2
       apiServer:
         timeoutForControlPlane: 4m0s
         extraArgs:
@@ -107,6 +107,8 @@ write_files:
       # start and enable docker for it to take affect
       systemctl start docker
       systemctl enable docker
+      # add "node" to host file
+      sed -i "s/$(hostname)/$(hostname)\tnode/" /etc/hosts
   - path: /opt/cloud/setup-k8s
     permissions: "0755"
     content: |


### PR DESCRIPTION
This PR fixes the following issue with `kubeadm` starting
```
[init] Using Kubernetes version: v1.27.0
[preflight] Running pre-flight checks
        [WARNING Hostname]: hostname "node" could not be reached
        [WARNING Hostname]: hostname "node": lookup node on 127.0.0.53:53: server misbehaving
```

- Ref: [/e2e-packet/cloud-config.yaml.tftpl#L50-L53](https://github.com/cloudnative-coop/space-templates/blob/005856d3af6399c191a09ac45a96d1a32cdc69fa/e2e-packet/cloud-config.yaml.tftpl#L50-L53)
```
      nodeRegistration:
        criSocket: unix:///var/run/containerd/containerd.sock
        imagePullPolicy: IfNotPresent
        name: node
```
Also, bumping Kubernetes version to [1.27.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#bug-or-regression)