### PR TITLE
add home dir whitelist

### DIFF
--- a/iipod/build/home/.config/direnv/direnv.toml
+++ b/iipod/build/home/.config/direnv/direnv.toml
@@ -1,0 +1,2 @@
+[whitelist]
+prefix = ["/home/ii"]


### PR DESCRIPTION
by default, when direnv enters a directory that  has a .envrc, it asks to run direnv allow.  Similarly, if you make any changes to that .envrc, you need to run direnv allow to run these changes.  By adding the homedir to the direnv whitelist, we say that any envrc it encounters in the dir and any child dirs it will allow automatically.

We want to show how you can clone a repo and cd into it with all the stuff already built.  This helps remove some of the manual steps to better demonstrate this.  We may find that this is tooo automatic though.